### PR TITLE
feat: support import as native meson subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('agbpack', 'c', default_options: 'c_std=gnu17,gnu11')
 
-executable('agbpack', [
+agbpack = executable('agbpack', [
     'rt/out/crt0_multiboot_bin.c',
     'rt/out/crt0_rom_bin.c',
     'src/main.c',
@@ -12,4 +12,7 @@ executable('agbpack', [
     'vendor/apultra/src/libdivsufsort/lib/divsufsort_utils.c',
     'vendor/apultra/src/libdivsufsort/lib/sssort.c',
     'vendor/apultra/src/libdivsufsort/lib/trsort.c'
-], include_directories: include_directories('rt/out', 'src', 'vendor/apultra/src', 'vendor/apultra/src/libdivsufsort/include'))
+], include_directories: include_directories('rt/out', 'src', 'vendor/apultra/src', 'vendor/apultra/src/libdivsufsort/include'),
+native: true)
+
+meson.override_find_program('agbpack', agbpack)


### PR DESCRIPTION
Setting an override for find_program and marking the executable as a native tool allows for users to import the project into existing meson-based projects.

This can be paired with an `agbpack.wrap` in `subprojects/`:
```ini
[wrap-git]
url = https://github.com/WonderfulToolchain/agbpack.git
revision = main
clone-recursive = true

[provide]
program_names = agbpack
```

And used within a meson project's `meson.build`:
```py
    subproject('agbpack')
    agbpack = find_program('agbpack', required: true)

    # Base multiboot elf binary
    multi = executable(
        name + '-multi',
        sources,
        cpp_args: ['-DMULTIBOOT'],
        c_args: ['-DMULTIBOOT'],
        include_directories: includes,
        dependencies: dependencies_multi,
        name_suffix: 'elf',
    )

    # Base multiboot ROM
    multi_base = custom_target(
        name + '-multi-base',
        input: multi,
        output: name + '-multi-base.gba',
        command: [agbpack, '@INPUT@', '@OUTPUT@'],
    )
```